### PR TITLE
Group作成画面のデザインを調整した

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,11 @@ inherit_gem:
   rubocop-fjord:
     - "config/rubocop.yml"
     - "config/rails.yml"
+
+RSpec/ExampleLength:
+  Exclude:
+    - spec/system/*
+
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/system/*

--- a/Gemfile
+++ b/Gemfile
@@ -82,4 +82,5 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'selenium-webdriver'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rails-i18n', '~> 7.0.0'
 gem 'slim-rails'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,7 @@ group :development do
   gem 'rubocop-rspec', require: false
   gem 'slim_lint', require: false
 end
+
+group :test do
+  gem 'capybara'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
@@ -82,6 +84,15 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -127,6 +138,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.3)
+    matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.22.2)
     msgpack (1.7.2)
@@ -160,6 +172,7 @@ GEM
     pg (1.5.5)
     psych (5.1.2)
       stringio
+    public_suffix (5.0.4)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -318,6 +331,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.13)
 
 PLATFORMS
@@ -330,6 +345,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  capybara
   debug
   factory_bot_rails
   html2slim-ruby3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,12 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.18.1)
+      base64 (~> 0.2)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     slim (5.2.1)
       temple (~> 0.10.0)
       tilt (>= 2.1.0)
@@ -328,6 +334,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
     webrick (1.8.1)
+    websocket (1.2.10)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -364,6 +371,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  selenium-webdriver
   slim-rails
   slim_lint
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -335,6 +338,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.2)
+  rails-i18n (~> 7.0.0)
   redis (>= 4.0.1)
   rspec-rails (~> 6.1.0)
   rubocop

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,7 +19,7 @@ class GroupsController < ApplicationController
     @group = Group.new(group_params)
 
     if @group.save
-      redirect_to group_url(@group), notice: 'Group was successfully created.'
+      redirect_to group_url(@group), notice: '2次会グループが作成されました'
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -6,29 +6,39 @@
         - group.errors.each do |error|
           li = error.full_message
 
-  div
+  div.mb-4
     = form.label :hashtag, style: 'display: block'
     = form.text_field :hashtag
+    p.text-gray-400.text-sm
+      | 現在参加しているイベントのハッシュタグを入力してください。
 
-  div
+  div.mb-4
     = form.label :name, style: 'display: block'
     = form.text_field :name
+    p.text-gray-400.text-sm
+      | 2次会のテーマを含む名前がおすすめです。
 
-  div
+  div.mb-4
     = form.label :details, style: 'display: block'
     = form.text_area :details
+    p.text-gray-400.text-sm
+      | どんな人に参加して欲しいですか？どんな2次会を開催予定ですか？<br>例）女性限定、イベントの参加者で交流したい！
 
-  div
+  div.mb-4
     = form.label :capacity, style: 'display: block'
     = form.number_field :capacity
 
-  div
+  div.mb-4
     = form.label :location, style: 'display: block'
     = form.text_field :location
+    p.text-gray-400.text-sm
+      | 例）〇〇駅周辺の居酒屋
 
-  div
+  div.mb-4
     = form.label :payment_method, style: 'display: block'
     = form.text_field :payment_method
+    p.text-gray-400.text-sm
+      | トラブル防止のため、事前に会計方法を決めておきましょう。<br>例）乾杯前に3000円集金します、個別会計
 
   div
     = form.submit

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -6,35 +6,35 @@
         - group.errors.each do |error|
           li = error.full_message
 
-  div.mb-4
+  .mb-4
     = form.label :hashtag, style: 'display: block'
     = form.text_field :hashtag
     p.text-gray-400.text-sm
       | 現在参加しているイベントのハッシュタグを入力してください。
 
-  div.mb-4
+  .mb-4
     = form.label :name, style: 'display: block'
     = form.text_field :name
     p.text-gray-400.text-sm
       | 2次会のテーマを含む名前がおすすめです。
 
-  div.mb-4
+  .mb-4
     = form.label :details, style: 'display: block'
     = form.text_area :details
     p.text-gray-400.text-sm
       | どんな人に参加して欲しいですか？どんな2次会を開催予定ですか？<br>例）女性限定、イベントの参加者で交流したい！
 
-  div.mb-4
+  .mb-4
     = form.label :capacity, style: 'display: block'
     = form.number_field :capacity
 
-  div.mb-4
+  .mb-4
     = form.label :location, style: 'display: block'
     = form.text_field :location
     p.text-gray-400.text-sm
       | 例）〇〇駅周辺の居酒屋
 
-  div.mb-4
+  .mb-4
     = form.label :payment_method, style: 'display: block'
     = form.text_field :payment_method
     p.text-gray-400.text-sm

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -1,7 +1,7 @@
 = form_with(model: group) do |form|
   - if group.errors.any?
     div style="color: red"
-      h2 = "#{pluralize(group.errors.count, 'error')} prohibited this group from being saved:"
+      h2 = t('errors.template.header', model: group.model_name.human, count: group.errors.count)
       ul
         - group.errors.each do |error|
           li = error.full_message

--- a/app/views/groups/new.html.slim
+++ b/app/views/groups/new.html.slim
@@ -1,8 +1,10 @@
-h1 New group
+h1.text-2xl.font-bold.mb-4
+  | 2次会グループを作成
+
+p.mb-4
+  | 2次会グループを作成して、イベントのハッシュタグをつけてXに投稿して参加者を募集しましょう。<br>作成した2次会グループページ上で参加者と連絡を取ることができます。
 
 == render 'form', group: @group
 
-br
-
 div
-  = link_to 'Back to groups', groups_path
+  = link_to 'キャンセル', groups_path

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,5 +10,5 @@ html
     = stylesheet_link_tag 'application', 'data-turbo-track': 'reload'
     = javascript_importmap_tags
   body
-    main.container.mx-auto.mt-28.px-5.flex
+    main.container.mx-auto.mt-28.px-5
       = yield

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,6 @@ module Nijikaigo
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,12 @@
+ja:
+  activerecord:
+    models:
+      group: 2次会グループ
+    attributes:
+      group:
+        hashtag: イベントのハッシュタグ
+        name: 2次会グループ名
+        details: 募集内容
+        capacity: 定員
+        location: 会場
+        payment_method: 会計方法

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -12,60 +12,60 @@ RSpec.describe Group, type: :model do
   it 'is invalid without a hashtag' do
     group.hashtag = nil
     group.valid?
-    expect(group.errors[:hashtag]).to include("can't be blank")
+    expect(group.errors[:hashtag]).to include('を入力してください')
   end
 
   it 'is invalid without a name' do
     group.name = nil
     group.valid?
-    expect(group.errors[:name]).to include("can't be blank")
+    expect(group.errors[:name]).to include('を入力してください')
   end
 
   it 'is invalid without a details' do
     group.details = nil
     group.valid?
-    expect(group.errors[:details]).to include("can't be blank")
+    expect(group.errors[:details]).to include('を入力してください')
   end
 
   it 'is invalid without a capacity' do
     group.capacity = nil
     group.valid?
-    expect(group.errors[:capacity]).to include("can't be blank")
+    expect(group.errors[:capacity]).to include('を入力してください')
   end
 
   it 'is invalid without a location' do
     group.location = nil
     group.valid?
-    expect(group.errors[:location]).to include("can't be blank")
+    expect(group.errors[:location]).to include('を入力してください')
   end
 
   it 'is invalid without a payment_method' do
     group.payment_method = nil
     group.valid?
-    expect(group.errors[:payment_method]).to include("can't be blank")
+    expect(group.errors[:payment_method]).to include('を入力してください')
   end
 
   it 'is invalid with capacity as string' do
     group.capacity = 'invalid'
     group.valid?
-    expect(group.errors[:capacity]).to include('is not a number')
+    expect(group.errors[:capacity]).to include('は数値で入力してください')
   end
 
   it 'is invalid with float capacity' do
     group.capacity = 3.5
     group.valid?
-    expect(group.errors[:capacity]).to include('must be an integer')
+    expect(group.errors[:capacity]).to include('は整数で入力してください')
   end
 
   it 'is invalid with zero capacity' do
     group.capacity = 0
     group.valid?
-    expect(group.errors[:capacity]).to include('must be greater than 0')
+    expect(group.errors[:capacity]).to include('は0より大きい値にしてください')
   end
 
   it 'is invalid with negative capacity' do
     group.capacity = -5
     group.valid?
-    expect(group.errors[:capacity]).to include('must be greater than 0')
+    expect(group.errors[:capacity]).to include('は0より大きい値にしてください')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium_chrome_headless

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe "Groups", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -1,9 +1,47 @@
 require 'rails_helper'
 
-RSpec.describe "Groups", type: :system do
-  before do
-    driven_by(:rack_test)
-  end
+RSpec.describe 'Groups', type: :system do
+  describe 'creating a new group' do
+    context 'with valid input' do
+      it 'creates the group' do
+        visit root_path
+        click_link 'New group'
+        expect(page).to have_current_path(new_group_path)
 
-  pending "add some scenarios (or delete) #{__FILE__}"
+        expect do
+          fill_in 'イベントのハッシュタグ', with: 'rubykaigi'
+          fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
+          fill_in '募集内容', with: '誰でも参加OK!!'
+          fill_in '定員', with: 10
+          fill_in '会場', with: '未定'
+          fill_in '会計方法', with: '割り勘'
+          click_button '登録する'
+
+          expect(page).to have_content 'Group was successfully created.'
+          expect(page).to have_content 'rubykaigi'
+          expect(page).to have_current_path(group_path(Group.last))
+        end.to change(Group, :count).by(1)
+      end
+    end
+
+    context 'with invalid input' do
+      it 'displays an error message' do
+        visit root_path
+        click_link 'New group'
+        expect(page).to have_current_path(new_group_path)
+
+        fill_in 'イベントのハッシュタグ', with: nil
+        fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
+        fill_in '募集内容', with: '誰でも参加OK!!'
+        fill_in '定員', with: 10
+        fill_in '会場', with: '未定'
+        fill_in '会計方法', with: '割り勘'
+        click_button '登録する'
+
+        expect(page).to have_content '1 error prohibited this group from being saved'
+        expect(page).to have_content 'イベントのハッシュタグを入力してください'
+        expect(page).to have_current_path(new_group_path)
+      end
+    end
+  end
 end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Groups', type: :system do
           fill_in '会計方法', with: '割り勘'
           click_button '登録する'
 
-          expect(page).to have_content 'Group was successfully created.'
+          expect(page).to have_content '2次会グループが作成されました'
           expect(page).to have_content 'rubykaigi'
           expect(page).to have_current_path(group_path(Group.last))
         end.to change(Group, :count).by(1)

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Groups', type: :system do
         fill_in '会計方法', with: '割り勘'
         click_button '登録する'
 
-        expect(page).to have_content '1 error prohibited this group from being saved'
+        expect(page).to have_content '2次会グループに1個のエラーが発生しました'
         expect(page).to have_content 'イベントのハッシュタグを入力してください'
         expect(page).to have_current_path(new_group_path)
       end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Groups', type: :system do


### PR DESCRIPTION
## Issue
- #52 

## PRの種類
- [ ] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [x] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ作成画面のデザインを調整しました
  - ページの説明文を追加
  - フォームの各項目に説明文を追加
  - 日本語対応
  - CSSを調整
- グループ作成のシステムスペックを追加しました

## 参考
<!-- 参考記事, 関連PR・issue  -->
- [Docs - Tailwind CSS](https://tailwindcss.com/docs/installation)
- [slim-template/slim](https://github.com/slim-template/slim)
- [Rails 国際化（I18n）API - Railsガイド](https://railsguides.jp/i18n.html)
- [svenfuchs/rails-i18n](https://github.com/svenfuchs/rails-i18n)
- [Everyday Rails - RSpecによるRailsテスト入門: 6章](https://github.com/JunichiIto/everydayrails-rspec-jp-2024)

## 動作確認方法
1. `feat/#52/add-group-creation`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. 「New group」 > フォームの各項目を入力 > 「登録する」で2次会グループが作成できることを確認する

## スクリーンショット
### 変更前
`/groups/new`
![new](https://github.com/djkazunoko/nijikaigo/assets/65595901/289fcad2-5dd6-463e-b40d-c7a20b8a3d0e)

### 変更後
`/groups/new`
![new](https://github.com/djkazunoko/nijikaigo/assets/65595901/32f8d75b-e333-4310-8f8d-dbcacca1c264)
