### PR TITLE
Group編集画面のデザインを調整した

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -27,7 +27,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to group_url(@group), notice: 'Group was successfully updated.'
+      redirect_to group_url(@group), notice: '2次会グループが更新されました'
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -1,10 +1,7 @@
-h1 Editing group
+h1.text-2xl.font-bold.mb-4
+  | 2次会グループを編集
 
 == render 'form', group: @group
 
-br
-
 div
-  => link_to 'Show this group', @group
-  '|
-  =< link_to 'Back to groups', groups_path
+  = link_to 'キャンセル', @group

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -46,4 +46,38 @@ RSpec.describe 'Groups', type: :system do
       end
     end
   end
+
+  describe 'updating a group' do
+    let(:group) { FactoryBot.create(:group) }
+
+    context 'with valid input' do
+      it 'updates the group' do
+        visit group_path(group)
+        click_link 'Edit this group'
+        expect(page).to have_current_path(edit_group_path(group))
+
+        fill_in '会場', with: 'とある居酒屋'
+        click_button '更新する'
+
+        expect(page).to have_content '2次会グループが更新されました'
+        expect(page).to have_content 'とある居酒屋'
+        expect(page).to have_current_path(group_path(group))
+      end
+    end
+
+    context 'with invalid input' do
+      it 'displays an error message' do
+        visit group_path(group)
+        click_link 'Edit this group'
+        expect(page).to have_current_path(edit_group_path(group))
+
+        fill_in '会場', with: ''
+        click_button '更新する'
+
+        expect(page).to have_content '2次会グループに1個のエラーが発生しました'
+        expect(page).to have_content '会場を入力してください'
+        expect(page).to have_current_path(edit_group_path(group))
+      end
+    end
+  end
 end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -32,17 +32,19 @@ RSpec.describe 'Groups', type: :system do
         click_link 'New group'
         expect(page).to have_current_path(new_group_path)
 
-        fill_in 'イベントのハッシュタグ', with: ''
-        fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
-        fill_in '募集内容', with: '誰でも参加OK!!'
-        fill_in '定員', with: 10
-        fill_in '会場', with: '未定'
-        fill_in '会計方法', with: '割り勘'
-        click_button '登録する'
+        expect do
+          fill_in 'イベントのハッシュタグ', with: ''
+          fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
+          fill_in '募集内容', with: '誰でも参加OK!!'
+          fill_in '定員', with: 10
+          fill_in '会場', with: '未定'
+          fill_in '会計方法', with: '割り勘'
+          click_button '登録する'
 
-        expect(page).to have_content '2次会グループに1個のエラーが発生しました'
-        expect(page).to have_content 'イベントのハッシュタグを入力してください'
-        expect(page).to have_current_path(new_group_path)
+          expect(page).to have_content '2次会グループに1個のエラーが発生しました'
+          expect(page).to have_content 'イベントのハッシュタグを入力してください'
+          expect(page).to have_current_path(new_group_path)
+        end.not_to change(Group, :count)
       end
     end
   end

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Groups', type: :system do
         click_link 'New group'
         expect(page).to have_current_path(new_group_path)
 
-        fill_in 'イベントのハッシュタグ', with: nil
+        fill_in 'イベントのハッシュタグ', with: ''
         fill_in '2次会グループ名', with: 'みんなで飲みましょう!!'
         fill_in '募集内容', with: '誰でも参加OK!!'
         fill_in '定員', with: 10


### PR DESCRIPTION
## Issue
- #53

## PRの種類
- [ ] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ編集画面のデザインを調整しました
  - 日本語対応
  - CSSを調整
- グループ編集のシステムスペックを追加しました
- グループ作成のシステムスペックを一部修正しました

## 動作確認方法
1. `feat/#53/add-group-editing`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. 任意のグループを作成する
4. 作成したグループの詳細画面の「Edit this group」を選択 > フォームの各項目を編集 > 「更新する」を選択して2次会グループが編集できることを確認する

## スクリーンショット
### 変更前
`/groups/{ID}/edit`
![edit_before](https://github.com/djkazunoko/nijikaigo/assets/65595901/429df973-0695-4808-b215-f7bb0265c8ca)

### 変更後
`/groups/{ID}/edit`
![edit_after](https://github.com/djkazunoko/nijikaigo/assets/65595901/3a5e7921-4969-485c-bad3-e84c29b11ad2)