### PR TITLE
Group削除機能を一部修正した

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -36,7 +36,7 @@ class GroupsController < ApplicationController
   def destroy
     @group.destroy!
 
-    redirect_to groups_url, notice: 'Group was successfully destroyed.'
+    redirect_to groups_url, notice: '2次会グループが削除されました'
   end
 
   private

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -7,4 +7,4 @@ div
   '|
   =< link_to 'Back to groups', groups_path
 
-  = button_to 'Destroy this group', @group, method: :delete
+  = button_to 'Destroy this group', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Groups', type: :system do
+  let(:group) { FactoryBot.create(:group) }
+
   describe 'creating a new group' do
     context 'with valid input' do
       it 'creates the group' do
@@ -50,8 +52,6 @@ RSpec.describe 'Groups', type: :system do
   end
 
   describe 'updating a group' do
-    let(:group) { FactoryBot.create(:group) }
-
     context 'with valid input' do
       it 'updates the group' do
         visit group_path(group)
@@ -80,6 +80,22 @@ RSpec.describe 'Groups', type: :system do
         expect(page).to have_content '会場を入力してください'
         expect(page).to have_current_path(edit_group_path(group))
       end
+    end
+  end
+
+  describe 'deleting a group' do
+    it 'deletes the group' do
+      visit group_path(group)
+
+      expect do
+        accept_confirm do
+          click_button 'Destroy this group'
+        end
+
+        expect(page).to have_content '2次会グループが削除されました'
+        expect(page).not_to have_content 'rubykaigi'
+        expect(page).to have_current_path(groups_path)
+      end.to change(Group, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
## Issue
- #54

## PRの種類
- [x] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [x] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ削除ボタンクリック後に確認ダイアログを表示するようにしました
- グループ削除時に表示されるフラッシュメッセージを日本語に変更しました
- グループ削除のシステムスペックを追加しました

## 動作確認方法
1. `feat/#54/add-group-deletion`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. 任意のグループを作成する
4. 作成したグループの詳細画面の「Destroy this group」を選択 > 「本当に削除しますか？」確認ダイアログの「OK」を選択して2次会グループが削除できることを確認する

## スクリーンショット
### 変更前
<img width="439" alt="delete_before_1" src="https://github.com/djkazunoko/nijikaigo/assets/65595901/fd0118ca-f0fb-4c81-8f23-290d6d8ccc5c">


### 変更後
<img width="1080" alt="delete_after_1" src="https://github.com/djkazunoko/nijikaigo/assets/65595901/d657739d-14f1-4f8a-839f-1d39885795bc">

<img width="439" alt="delete_after_2" src="https://github.com/djkazunoko/nijikaigo/assets/65595901/d560b4d8-2d43-4b7d-b66f-9ee85f1d0b3e">