### PR TITLE
Group一覧画面のデザインを調整した

### DIFF
--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -1,11 +1,28 @@
 p style="color: green" = notice
 
-h1 Groups
+h1.text-3xl.font-bold.mb-4
+  | 2次会GO！
+
+p.mb-4
+  | 2次会GO！は、テック系イベントの二次会参加者を簡単に集めることができる、二次会参加者募集ツールです。
+
+.mb-4
+  = link_to '2次会グループを作成', new_group_path
+
+p.text-xl.font-bold.mb-4
+  | 2次会グループ一覧
 
 #groups
   - @groups.each do |group|
-    == render group
     p
-      = link_to 'Show this group', group
-
-= link_to 'New group', new_group_path
+      = "#{group.hashtag} の2次会"
+    p
+      = group.name
+    p
+      = group.details
+    p
+      = "0 / #{group.capacity}人"
+    p
+      = "▼ #{group.location}"
+    p.mb-4
+      = link_to '詳細を見る', group

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Groups', type: :system do
     context 'with valid input' do
       it 'creates the group' do
         visit root_path
-        click_link 'New group'
+        click_link '2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
 
         expect do
@@ -31,7 +31,7 @@ RSpec.describe 'Groups', type: :system do
     context 'with invalid input' do
       it 'displays an error message' do
         visit root_path
-        click_link 'New group'
+        click_link '2次会グループを作成'
         expect(page).to have_current_path(new_group_path)
 
         expect do


### PR DESCRIPTION
## Issue
- #55 

## PRの種類
- [ ] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [ ] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ一覧表示画面(トップページ)にサービス名とサービスの説明文を追加しました
- グループ一覧表示画面のデザインを調整しました
- グループのシステムスペックを一部修正しました

## 動作確認方法
1. `feat/#55/add-group-index-page`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. `/groups`の表示を確認する

## スクリーンショット
### 変更前
`/groups`
![groups_before](https://github.com/djkazunoko/nijikaigo/assets/65595901/f65e49e5-d3ab-4965-a676-0c5cc8a240fc)

### 変更後
`/groups`
![groups_after](https://github.com/djkazunoko/nijikaigo/assets/65595901/b370b4f8-b4cc-4060-8a68-b965bda22fb4)