### PR TITLE
グループ詳細画面のデザインを調整した

### DIFF
--- a/app/views/groups/_group.html.slim
+++ b/app/views/groups/_group.html.slim
@@ -1,19 +1,13 @@
 div id="#{dom_id group}"
   p
-    strong Hashtag:
-    =< group.hashtag
+    = "#{group.hashtag} の2次会"
   p
-    strong Name:
-    =< group.name
+    = group.name
   p
-    strong Details:
-    =< group.details
+    = "#{Group.human_attribute_name('details')}: #{group.details}"
   p
-    strong Capacity:
-    =< group.capacity
+    = "参加者: 0 / #{group.capacity}人"
   p
-    strong Location:
-    =< group.location
+    = "#{Group.human_attribute_name('location')}: #{group.location}"
   p
-    strong Payment method:
-    =< group.payment_method
+    = "#{Group.human_attribute_name('payment_method')}: #{group.payment_method}"

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,10 +1,11 @@
 p style="color: green" = notice
 
-== render @group
+.mb-4
+  == render @group
 
 div
-  => link_to 'Edit this group', edit_group_path(@group)
-  '|
-  =< link_to 'Back to groups', groups_path
+  = link_to '編集', edit_group_path(@group)
 
-  = button_to 'Destroy this group', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }
+  = button_to '削除', @group, method: :delete, data: { turbo_confirm: '本当に削除しますか？' }
+
+  = link_to '2次会グループ一覧に戻る', groups_path

--- a/spec/system/groups_spec.rb
+++ b/spec/system/groups_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Groups', type: :system do
     context 'with valid input' do
       it 'updates the group' do
         visit group_path(group)
-        click_link 'Edit this group'
+        click_link '編集'
         expect(page).to have_current_path(edit_group_path(group))
 
         fill_in '会場', with: 'とある居酒屋'
@@ -70,7 +70,7 @@ RSpec.describe 'Groups', type: :system do
     context 'with invalid input' do
       it 'displays an error message' do
         visit group_path(group)
-        click_link 'Edit this group'
+        click_link '編集'
         expect(page).to have_current_path(edit_group_path(group))
 
         fill_in '会場', with: ''
@@ -89,7 +89,7 @@ RSpec.describe 'Groups', type: :system do
 
       expect do
         accept_confirm do
-          click_button 'Destroy this group'
+          click_button '削除'
         end
 
         expect(page).to have_content '2次会グループが削除されました'


### PR DESCRIPTION
## Issue
- #56

## PRの種類
- [ ] feat: 機能追加
- [ ] bugfix: バグ修正
- [ ] docs: ドキュメント更新
- [x] style: コードの意味に影響しない変更
- [ ] refactor: リファクタリング
- [ ] perf: パフォーマンス向上
- [ ] test: テスト関連
- [ ] chore: ビルド、補助ツール、ライブラリ関連、その他

## 詳細
<!-- 開発者目線、ユーザ目線の変更点を分けて書く -->
- グループ詳細表示画面のデザインを調整しました
- グループのシステムスペックを一部修正しました

## 動作確認方法
1. `feat/#56/add-group-show-page`をローカルに取り込む
2. `bin/dev`でサーバを起動し、`localhost:3000`にアクセス
3. `/groups/{ID}`の表示を確認する

## スクリーンショット
### 変更前
`/groups/{ID}`
![show_before](https://github.com/djkazunoko/nijikaigo/assets/65595901/d56e6f63-26be-4010-82cb-bd27d33bef18)

### 変更後
`/groups/{ID}`
![show_after](https://github.com/djkazunoko/nijikaigo/assets/65595901/ba2bdb0d-8abc-4ee8-84f4-01d9d41c0436)